### PR TITLE
fix: improve description list formatting in sidebars and comments

### DIFF
--- a/lib/dndcomment.sty
+++ b/lib/dndcomment.sty
@@ -49,6 +49,11 @@
 \cs_new_protected:Nn \__dnd_start_comment:nn
   {
     \begin {__dnd_comment} [ #1, #2 ]
+    \setlist[description]{nolistsep,listparindent=8pt,topsep=0pt,itemsep=0pt,parsep=0pt,partopsep=0pt,font={\bfseries\sffamily}}
+    % Redefine description environment to automatically add \noindent and spacing before/after
+    \let\olddescription\description
+    \let\endolddescription\enddescription
+    \renewenvironment{description}{\vspace{0.5\baselineskip}\noindent\olddescription}{\endolddescription\vspace{0.5\baselineskip}}
   }
 
 \cs_generate_variant:Nn \__dnd_start_comment:nn { nV }

--- a/lib/dndsidebar.sty
+++ b/lib/dndsidebar.sty
@@ -58,6 +58,11 @@
 \cs_new_protected:Nn \__dnd_start_sidebar:nn
   {
     \begin {__dnd_sidebar} [ #1, #2 ]
+    \setlist[description]{nolistsep,listparindent=8pt,topsep=0pt,itemsep=0pt,parsep=0pt,partopsep=0pt,font={\bfseries\sffamily}}
+    % Redefine description environment to automatically add \noindent and spacing before/after
+    \let\olddescription\description
+    \let\endolddescription\enddescription
+    \renewenvironment{description}{\vspace{0.5\baselineskip}\noindent\olddescription}{\endolddescription\vspace{0.5\baselineskip}}
   }
 
 \cs_generate_variant:Nn \__dnd_start_sidebar:nn { nV }


### PR DESCRIPTION
- Fix first item indentation bug with auto-noindent
- Use correct sans-serif font instead of serif
- Add 0.5 baselineskip spacing before/after lists
- Increase listparindent to 8pt for better visual separation

Affects DndSidebar and DndComment environments equally.


_Before:_

<img width="1240" height="1754" alt="before" src="https://github.com/user-attachments/assets/18a8f120-4c86-4359-bc31-42a64603cdd5" />


_After:_

<img width="1240" height="1754" alt="after" src="https://github.com/user-attachments/assets/1d858251-22cd-44a3-94cb-88248103d9d5" />
