### PR TITLE
Fix \DnDArea breaking in TeXLive 2025+

### DIFF
--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -752,7 +752,7 @@
     distance .choice:,
     distance .choices:nn =
       { both, melee, ranged }
-      { \tl_set:Nn \l__dnd_attack_distance_tl {\l_keys_choice_tl} },
+      { \tl_set:Nn \l__dnd_attack_distance_tl { #1 } },
     distance .initial:n  = both,
     type .choice:,
     type / weapon .code:n = { \tl_set:Nn \l__dnd_attack_type_tl {\weaponname} },

--- a/lib/dndsections.sty
+++ b/lib/dndsections.sty
@@ -278,7 +278,7 @@
     area-num-depth .choice:,
     area-num-depth .choices:nn =
       { 1, 2, 3, 4 }
-      { \tl_set:Nn \l__dnd_area_num_depth_tl {\l_keys_choice_tl} },
+      { \tl_set:Nn \l__dnd_area_num_depth_tl {#1} },
     area-num-depth .initial:n  = 2, % subsection
   }
 


### PR DESCRIPTION
Encountered an issue where `\DndArea` wasn't rendering headings in a fresh install of TeXLive 2025 and discovered upstream has a patch for this issue. Addressed in PR 379: https://github.com/rpgtex/DND-5e-LaTeX-Template/pull/379

also fixes something in the monster stat block, see upstream PR for details.